### PR TITLE
Use pocketlint for running pylint on pyparted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,9 @@ test: all
 	@env PYTHONPATH=$$(find $$(pwd) -name "*.so" | head -n 1 | xargs dirname):src/parted:src \
 	$(PYTHON) -m unittest discover -v
 
-check: all
-	env PYTHONPATH=$$(find $$(pwd) -name "*.so" | head -n 1 | xargs dirname):src/parted:src \
+check: clean
+	env PYTHON=python3 $(MAKE) ; \
+	env PYTHON=python3 PYTHONPATH=$$(find $$(pwd) -name "*.so" | head -n 1 | xargs dirname):src/parted:src \
 	tests/pylint/runpylint.py
 
 ChangeLog:
@@ -96,4 +97,4 @@ install: all
 	@$(PYTHON) setup.py install --root $(DESTDIR) -c -O1
 
 clean:
-	@$(PYTHON) setup.py clean
+	-rm -r build

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,6 @@ VERSION       = $(shell $(PYTHON) setup.py --version)
 
 TAG           = $(PACKAGE)-$(VERSION)
 
-PYLINTOPTS    = src/parted/*py --msg-template='{msg_id}:{line:3d},{column}: {obj}: {msg}' --rcfile=/dev/null -r n --disable=C,R --disable=W0141,W0212,W0511,W0613,W0702,E1103
-
 default: all
 
 all:
@@ -41,7 +39,7 @@ test: all
 
 check: all
 	env PYTHONPATH=$$(find $$(pwd) -name "*.so" | head -n 1 | xargs dirname):src/parted:src \
-	pylint --extension-pkg-whitelist=_ped $(PYLINTOPTS) src/parted/*.py
+	tests/pylint/runpylint.py
 
 ChangeLog:
 	git log > ChangeLog

--- a/Makefile
+++ b/Makefile
@@ -99,4 +99,3 @@ install: all
 
 clean:
 	@$(PYTHON) setup.py clean
-	@[ -d .git ] && git clean -d -x -f

--- a/examples/make_one_primary_partition.py
+++ b/examples/make_one_primary_partition.py
@@ -57,7 +57,7 @@ class ExampleDevice(object):
         @rtype:     str
         """
         names = glob('{}[0-9]*'.format(self.path))
-        self.logger.debug('has partitions {}'.format(names))
+        self.logger.debug('has partitions %s', names)
         return names
 
     def partition(self):
@@ -72,17 +72,17 @@ class ExampleDevice(object):
         """
         self.logger.info('creating primary partition')
         device = parted.getDevice(self.path)
-        self.logger.debug('created {}'.format(device))
+        self.logger.debug('created %s', device)
         disk = parted.freshDisk(device, 'msdos')
-        self.logger.debug('created {}'.format(disk))
+        self.logger.debug('created %s', disk)
         geometry = parted.Geometry(device=device, start=1,
                                    length=device.getLength() - 1)
-        self.logger.debug('created {}'.format(geometry))
+        self.logger.debug('created %s', geometry)
         filesystem = parted.FileSystem(type='ext3', geometry=geometry)
-        self.logger.debug('created {}'.format(filesystem))
+        self.logger.debug('created %s', filesystem)
         partition = parted.Partition(disk=disk, type=parted.PARTITION_NORMAL,
                                      fs=filesystem, geometry=geometry)
-        self.logger.debug('created {}'.format(partition))
+        self.logger.debug('created %s', partition)
         disk.addPartition(partition=partition,
                           constraint=device.optimalAlignedConstraint)
         partition.setFlag(parted.PARTITION_BOOT)
@@ -96,7 +96,7 @@ class ExampleDevice(object):
         @param dev_path:    Device path of the partition to be wiped.
         @type dev_path:     str
         """
-        self.logger.debug('wiping {!r}'.format(dev_path))
+        self.logger.debug('wiping %s', dev_path)
         with open(dev_path, 'wb') as p:
             p.write(bytearray(1024))
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@
 #
 # Author(s): David Cantrell <dcantrell@redhat.com>
 #            Alex Skinner <alex@lx.lc>
+#
+# pylint: skip-file
 
 import subprocess
 import glob

--- a/src/fdisk/fdisk.py
+++ b/src/fdisk/fdisk.py
@@ -64,8 +64,8 @@ def listPartitionTable(path, sectorsize, showsectors, showblocks):
                          partition.fileSystem))
 
     colLength = 0
-    for slice in partlist:
-        (partition, path, bootable, start, end, length, type, fs) = slice
+    for parts in partlist:
+        (partition, path, bootable, start, end, length, ty, fs) = parts
         if len(path) > colLength:
             colLength = len(path)
 
@@ -76,8 +76,8 @@ def listPartitionTable(path, sectorsize, showsectors, showblocks):
 
     sys.stdout.write("%-11s %-4s %-11s %-11s %-12s %-4s %s\n" % ("Device", "Boot", "Start", "End", "Blocks", "Id", "System",))
 
-    for slice in partlist:
-        (partition, path, bootable, start, end, length, type, fs) = slice
+    for parts in partlist:
+        (partition, path, bootable, start, end, length, ty, fs) = parts
 
         if bootable:
             bootflag = '*'
@@ -123,11 +123,11 @@ def listPartitionTable(path, sectorsize, showsectors, showblocks):
 def main(argv):
     cmd = os.path.basename(sys.argv[0])
     opts, args = [], []
-    help, list, showsectors, showblocks = False, False, False, False
+    showhelp, showlist, showsectors, showblocks = False, False, False, False
     sectorsize, cylinders, heads, sectors = None, None, None, None
 
     if len(sys.argv) == 1:
-        help = True
+        showhelp = True
 
     try:
         opts, args = getopt.getopt(sys.argv[1:], "lb:C:H:S:usV?",
@@ -135,11 +135,11 @@ def main(argv):
                                     "heads=", "sectors=", "showsectors",
                                     "showblocks", "version", "help"])
     except getopt.GetoptError:
-        help = True
+        showhelp = True
 
     for o, a in opts:
         if o in ('-l', '--list'):
-            list = True
+            showlist = True
         elif o in ('-b', '--sectorsize'):
             sectorsize = a
         elif o in ('-C', '--cylinders'):
@@ -160,14 +160,14 @@ def main(argv):
             sys.exit(0)
         else:
             sys.stderr.write("Invalid option: %s\n\n" % (o,))
-            help = True
+            showhelp = True
 
-    if help:
+    if showhelp:
         usage(cmd)
         sys.exit(1)
 
     for arg in args:
-        if list:
+        if showlist:
             listPartitionTable(arg, sectorsize, showsectors, showblocks)
 
 if __name__ == "__main__":

--- a/src/fdisk/fdisk.py
+++ b/src/fdisk/fdisk.py
@@ -41,6 +41,13 @@ def usage(cmd):
     sys.stdout.write("   -V, --version               Show fdisk version\n")
     sys.stdout.write("   -?, --help                  Display fdisk usage screen\n")
 
+def displayVersion(cmd):
+    ver = parted.version()
+
+    sys.stdout.write("%s:\n" % (cmd,))
+    sys.stdout.write("pyparted version: %s.%s.%s\n" % (ver["pyparted"][0], ver["pyparted"][1], ver["pyparted"][2]))
+    sys.stdout.write("libparted version: %s\n" % ver["libparted"])
+
 def listPartitionTable(path, sectorsize, showsectors, showblocks):
     device = parted.getDevice(path)
     (cylinders, heads, sectors) = device.biosGeometry
@@ -65,7 +72,7 @@ def listPartitionTable(path, sectorsize, showsectors, showblocks):
 
     colLength = 0
     for parts in partlist:
-        (partition, path, bootable, start, end, length, ty, fs) = parts
+        path = parts[1]
         if len(path) > colLength:
             colLength = len(path)
 
@@ -84,7 +91,7 @@ def listPartitionTable(path, sectorsize, showsectors, showblocks):
         else:
             bootflag = ''
 
-        sys.stdout.write("%-11s %-4s %-11d %-11d %-12d %-4s" % (path, bootflag, start, end, length, type,))
+        sys.stdout.write("%-11s %-4s %-11d %-11d %-12d %-4s" % (path, bootflag, start, end, length, ty,))
 
         if fs is None:
             # no filesystem, check flags
@@ -118,13 +125,14 @@ def listPartitionTable(path, sectorsize, showsectors, showblocks):
 #/dev/sda3   *        4203        4229      204800   83  Linux
 #/dev/sda4            4229       30402   210234515+  8e  Linux LVM
 
-
-
 def main(argv):
     cmd = os.path.basename(sys.argv[0])
     opts, args = [], []
     showhelp, showlist, showsectors, showblocks = False, False, False, False
-    sectorsize, cylinders, heads, sectors = None, None, None, None
+
+    # These three are unused for now so I'm marking them with an underscore
+    # to make pylint happy.
+    sectorsize, _cylinders, _heads, _sectors = None, None, None, None
 
     if len(sys.argv) == 1:
         showhelp = True
@@ -143,11 +151,11 @@ def main(argv):
         elif o in ('-b', '--sectorsize'):
             sectorsize = a
         elif o in ('-C', '--cylinders'):
-            cylinders = a
+            _cylinders = a
         elif o in ('-H', '--heads'):
-            heads = a
+            _heads = a
         elif o in ('-S', '--sectors'):
-            sectors = a
+            _sectors = a
         elif o in ('-u', '--showsectors'):
             showsectors = True
         elif o in ('-s', '--showblocks'):

--- a/src/parted/__init__.py
+++ b/src/parted/__init__.py
@@ -164,7 +164,7 @@ from parted.decorators import localeC
 if sys.version_info >= (3,):
     string_types = str
 else:
-    string_types = basestring
+    string_types = basestring # pylint: disable=undefined-variable
 
 partitionTypesDict = {
     0x00: "Empty",

--- a/src/parted/decorators.py
+++ b/src/parted/decorators.py
@@ -30,6 +30,7 @@ def localeC(fn):
     def _setlocale(l):
         try:
             locale.setlocale(locale.LC_MESSAGES, l)
+        # pylint: disable=bare-except
         except:
             pass
 

--- a/src/parted/device.py
+++ b/src/parted/device.py
@@ -22,6 +22,10 @@
 #            Alex Skinner <alex@lx.lc>
 #
 
+import sys
+if sys.version_info >= (3, ):
+    long = int
+
 import math
 import warnings
 

--- a/src/parted/disk.py
+++ b/src/parted/disk.py
@@ -391,6 +391,7 @@ class Disk(object):
         """Return the extended Partition, if any, on this Disk."""
         try:
             return parted.Partition(disk=self, PedPartition=self.__disk.extended_partition())
+        # pylint: disable=bare-except
         except:
             return None
 
@@ -473,7 +474,7 @@ while True:
     try:
         __type = _ped.disk_type_get_next(__type)
         diskType[__type.name] = __type
-    except:
+    except (IndexError, TypeError, _ped.UnknownTypeException):
         break
 
 # collect all disk flags and store them in a hash

--- a/src/parted/filesystem.py
+++ b/src/parted/filesystem.py
@@ -107,5 +107,5 @@ while True:
     try:
         __type = _ped.file_system_type_get_next(__type)
         fileSystemType[__type.name] = __type
-    except:
+    except (IndexError, TypeError, _ped.UnknownTypeException):
         break

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -54,7 +54,7 @@ class RequiresFileSystem(unittest.TestCase):
             try:
                 ty = _ped.file_system_type_get_next(ty)
                 self._fileSystemType[ty.name] = ty
-            except:
+            except (IndexError, TypeError, _ped.UnknownTypeException):
                 break
 
         (fd, self.path,) = tempfile.mkstemp(prefix="temp-device-")
@@ -173,7 +173,7 @@ class RequiresDiskTypes(unittest.TestCase):
             try:
                 ty = _ped.disk_type_get_next(ty)
                 self.disktype[ty.name] = ty
-            except:
+            except (IndexError, TypeError, _ped.UnknownTypeException):
                 break
 
 # Base class for any test case that requires a list being built via successive

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -47,13 +47,13 @@ class RequiresDevice(RequiresDeviceNode):
 class RequiresFileSystem(unittest.TestCase):
     def setUp(self):
         self._fileSystemType = {}
-        type = _ped.file_system_type_get_next()
-        self._fileSystemType[type.name] = type
+        ty = _ped.file_system_type_get_next()
+        self._fileSystemType[ty.name] = ty
 
         while True:
             try:
-                type = _ped.file_system_type_get_next(type)
-                self._fileSystemType[type.name] = type
+                ty = _ped.file_system_type_get_next(ty)
+                self._fileSystemType[ty.name] = ty
             except:
                 break
 
@@ -162,13 +162,13 @@ class RequiresPartition(RequiresDisk):
 class RequiresDiskTypes(unittest.TestCase):
     def setUp(self):
         self.disktype = {}
-        type = _ped.disk_type_get_next()
-        self.disktype[type.name] = type
+        ty = _ped.disk_type_get_next()
+        self.disktype[ty.name] = ty
 
         while True:
             try:
-                type = _ped.disk_type_get_next(type)
-                self.disktype[type.name] = type
+                ty = _ped.disk_type_get_next(ty)
+                self.disktype[ty.name] = ty
             except:
                 break
 

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -138,6 +138,10 @@ class RequiresDisk(RequiresDevice):
 
 # Base class for any test case that requires a filesystem made and mounted.
 class RequiresMount(RequiresDevice):
+    def setUp(self):
+        RequiresDevice.setUp(self)
+        self.mountpoint = None
+
     def mkfs(self):
         os.system("/sbin/mkfs.ext2 -F -q %s" % self.path)
 

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python3
+
+import os
+
+from pocketlint import PocketLintConfig, PocketLinter
+
+class PypartedLintConfig(PocketLintConfig):
+    @property
+    def extraArgs(self):
+        return ["--extension-pkg-whitelist", "_ped"]
+
+    @property
+    def pylintPlugins(self):
+        retval = super(PypartedLintConfig, self).pylintPlugins
+        retval.remove("pocketlint.checkers.eintr")
+        return retval
+
+if __name__ == "__main__":
+    conf = PypartedLintConfig()
+    linter = PocketLinter(conf)
+    rc = linter.run()
+    os._exit(rc)

--- a/tests/test__ped_alignment.py
+++ b/tests/test__ped_alignment.py
@@ -21,7 +21,7 @@
 
 import _ped
 import unittest
-from tests.baseclass import *
+from tests.baseclass import RequiresDevice, RequiresDeviceAlignment
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require

--- a/tests/test__ped_alignment.py
+++ b/tests/test__ped_alignment.py
@@ -68,9 +68,9 @@ class AlignmentGetSetTestCase(unittest.TestCase):
 class AlignmentDuplicateTestCase(unittest.TestCase):
     def setUp(self):
         self.a = _ped.Alignment(27, 49)
+        self.dup = self.a.duplicate()
 
     def runTest(self):
-        self.dup = self.a.duplicate()
         self.assertEqual(self.a.offset, self.dup.offset)
         self.assertEqual(self.a.grain_size, self.dup.grain_size)
 

--- a/tests/test__ped_alignment.py
+++ b/tests/test__ped_alignment.py
@@ -119,9 +119,9 @@ class AlignmentIntersectTestCase(unittest.TestCase):
         new_offset = verifyA.offset + x * delta_on_gcd * verifyA.grain_size
         new_grain_size = verifyA.grain_size * verifyB.grain_size / gcd
 
-        complex = self.complexA.intersect(self.complexB)
-        self.assertEqual(new_offset, complex.offset)
-        self.assertEqual(new_grain_size, complex.grain_size)
+        intersection = self.complexA.intersect(self.complexB)
+        self.assertEqual(new_offset, intersection.offset)
+        self.assertEqual(new_grain_size, intersection.grain_size)
 
 class AlignmentAlignUpTestCase(RequiresDeviceAlignment):
     def setUp(self):

--- a/tests/test__ped_alignment.py
+++ b/tests/test__ped_alignment.py
@@ -113,8 +113,8 @@ class AlignmentIntersectTestCase(unittest.TestCase):
         # complex test second, see libparted/cs/natmath.c for an explanation
         # of the math behind computing the intersection of two alignments
         (verifyA, verifyB) = self.orderAlignments(self.complexA, self.complexB)
-        (gcd, x, y) = self.extendedEuclid(verifyA.grain_size,
-                                          verifyB.grain_size)
+        (gcd, x, _y) = self.extendedEuclid(verifyA.grain_size,
+                                           verifyB.grain_size)
         delta_on_gcd = (verifyB.offset - verifyA.offset) / gcd
         new_offset = verifyA.offset + x * delta_on_gcd * verifyA.grain_size
         new_grain_size = verifyA.grain_size * verifyB.grain_size / gcd

--- a/tests/test__ped_chsgeometry.py
+++ b/tests/test__ped_chsgeometry.py
@@ -22,7 +22,7 @@
 import _ped
 import unittest
 
-from tests.baseclass import *
+from tests.baseclass import RequiresDevice
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require

--- a/tests/test__ped_constraint.py
+++ b/tests/test__ped_constraint.py
@@ -20,9 +20,8 @@
 #
 
 import _ped
-import unittest
 
-from tests.baseclass import *
+from tests.baseclass import RequiresDevice
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require

--- a/tests/test__ped_constraint.py
+++ b/tests/test__ped_constraint.py
@@ -104,9 +104,9 @@ class ConstraintDuplicateTestCase(RequiresDevice):
 
         self.c = _ped.Constraint(align1, align2, geom1, geom2, min_size=10,
                                  max_size=100)
+        self.dup = self.c.duplicate()
 
     def runTest(self):
-        self.dup = self.c.duplicate()
         self.assertEqual(self.c.min_size, self.dup.min_size)
         self.assertEqual(self.c.max_size, self.dup.max_size)
 

--- a/tests/test__ped_device.py
+++ b/tests/test__ped_device.py
@@ -22,7 +22,7 @@
 import _ped
 import unittest
 
-from tests.baseclass import *
+from tests.baseclass import RequiresDevice
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require

--- a/tests/test__ped_disk.py
+++ b/tests/test__ped_disk.py
@@ -22,7 +22,7 @@
 import _ped
 import unittest
 
-from tests.baseclass import *
+from tests.baseclass import RequiresDevice, RequiresLabeledDevice, RequiresDisk
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require

--- a/tests/test__ped_disktype.py
+++ b/tests/test__ped_disktype.py
@@ -45,8 +45,8 @@ class DiskTypeGetSetTestCase(RequiresDiskTypes):
                 bigint = int
                 uni = str
             else:
-                bigint = long
-                uni = unicode
+                bigint = long       # pylint: disable=undefined-variable
+                uni = unicode       # pylint: disable=undefined-variable
             self.assertIsInstance(t.name, uni)
             self.assertEqual(t.name, name)
             self.assertIsInstance(t.features, bigint)

--- a/tests/test__ped_disktype.py
+++ b/tests/test__ped_disktype.py
@@ -22,7 +22,7 @@
 import _ped
 import sys
 import unittest
-from tests.baseclass import *
+from tests.baseclass import RequiresDiskTypes
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require

--- a/tests/test__ped_filesystem.py
+++ b/tests/test__ped_filesystem.py
@@ -18,7 +18,6 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 #                    David Cantrell <dcantrell@redhat.com>
 #
-import _ped
 import unittest
 
 # One class per method, multiple tests per class.  For these simple methods,

--- a/tests/test__ped_geometry.py
+++ b/tests/test__ped_geometry.py
@@ -76,9 +76,9 @@ class GeometryDuplicateTestCase(RequiresDevice):
     def setUp(self):
         RequiresDevice.setUp(self)
         self.g = _ped.Geometry(self._device, start=0, length=100)
+        self.dup = self.g.duplicate()
 
     def runTest(self):
-        self.dup = self.g.duplicate()
         self.assertEqual(self.g.start, self.dup.start)
         self.assertEqual(self.g.length, self.dup.length)
         self.assertEqual(self.g.end, self.dup.end)
@@ -88,9 +88,10 @@ class GeometryIntersectTestCase(RequiresDevice):
         RequiresDevice.setUp(self)
         self.g1 = _ped.Geometry(self._device, start=0, length=100)
         self.g2 = _ped.Geometry(self._device, start=0, length=100)
+        self.i = None
 
     def runTest(self):
-       # g1 and g2 are the same, so their intersection is the same
+        # g1 and g2 are the same, so their intersection is the same
         self.i = self.g1.intersect(self.g2)
         self.assertEqual(self.i.start, self.g1.start)
         self.assertEqual(self.i.end, self.g1.end)

--- a/tests/test__ped_geometry.py
+++ b/tests/test__ped_geometry.py
@@ -19,8 +19,7 @@
 #
 
 import _ped
-import unittest
-from tests.baseclass import *
+from tests.baseclass import RequiresDevice
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require

--- a/tests/test__ped_partition.py
+++ b/tests/test__ped_partition.py
@@ -21,7 +21,7 @@
 import _ped
 import unittest
 
-from tests.baseclass import *
+from tests.baseclass import RequiresDisk, RequiresPartition
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require

--- a/tests/test__ped_ped.py
+++ b/tests/test__ped_ped.py
@@ -294,7 +294,7 @@ class FileSystemTypeGetTestCase(unittest.TestCase):
             # build on the test system
             try:
                 t = _ped.file_system_type_get(f)
-                self.assertIsInstance(_ped.file_system_type_get(f), _ped.FileSystemType, "Could not get fs type %s" % f)
+                self.assertIsInstance(t, _ped.FileSystemType, "Could not get fs type %s" % t)
             except _ped.UnknownTypeException:
                 pass
 

--- a/tests/test__ped_ped.py
+++ b/tests/test__ped_ped.py
@@ -24,10 +24,8 @@
 
 import _ped
 import unittest
-import os
-import tempfile
 
-from tests.baseclass import *
+from tests.baseclass import BuildList, RequiresDevice, RequiresFileSystem
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require

--- a/tests/test__ped_ped.py
+++ b/tests/test__ped_ped.py
@@ -121,9 +121,9 @@ class ConstraintNewFromMinMaxTestCase(RequiresDevice):
                           _ped.Geometry(self._device, 15, 25))
 
         # Now test a correct call.
-        min = _ped.Geometry(self._device, 10, 20)
-        max = _ped.Geometry(self._device, 0, 30)
-        constraint = _ped.constraint_new_from_min_max(min, max)
+        minimum = _ped.Geometry(self._device, 10, 20)
+        maximum = _ped.Geometry(self._device, 0, 30)
+        constraint = _ped.constraint_new_from_min_max(minimum, maximum)
 
         self.assertIsInstance(constraint, _ped.Constraint)
         self.assertTrue(constraint.is_solution(_ped.Geometry(self._device, 10, 20)))
@@ -136,8 +136,8 @@ class ConstraintNewFromMinTestCase(RequiresDevice):
     def runTest(self):
         self.assertRaises(TypeError, _ped.constraint_new_from_min, None)
 
-        min = _ped.Geometry(self._device, 10, 20)
-        constraint = _ped.constraint_new_from_min(min)
+        minimum = _ped.Geometry(self._device, 10, 20)
+        constraint = _ped.constraint_new_from_min(minimum)
 
         self.assertIsInstance(constraint, _ped.Constraint)
         self.assertTrue(constraint.is_solution(_ped.Geometry(self._device, 10, 20)))
@@ -149,8 +149,8 @@ class ConstraintNewFromMaxTestCase(RequiresDevice):
     def runTest(self):
         self.assertRaises(TypeError, _ped.constraint_new_from_max, None)
 
-        max = _ped.Geometry(self._device, 10, 20)
-        constraint = _ped.constraint_new_from_max(max)
+        maximum = _ped.Geometry(self._device, 10, 20)
+        constraint = _ped.constraint_new_from_max(maximum)
 
         self.assertIsInstance(constraint, _ped.Constraint)
         self.assertTrue(constraint.is_solution(_ped.Geometry(self._device, 10, 20)))
@@ -256,17 +256,17 @@ class DiskTypeGetNextTestCase(unittest.TestCase, BuildList):
 
 class FileSystemProbeTestCase(RequiresFileSystem):
     def runTest(self):
-        type = _ped.file_system_probe(self._geometry)
+        ty = _ped.file_system_probe(self._geometry)
 
         for name in self._fileSystemType.keys():
             if name == 'ext2':
-                self.assertEqual(type.name, name)
+                self.assertEqual(ty.name, name)
             else:
-                self.assertNotEqual(type.name, name)
+                self.assertNotEqual(ty.name, name)
 
 class FileSystemProbeSpecificTestCase(RequiresFileSystem):
     def runTest(self):
-        for (name, type,) in self._fileSystemType.items():
+        for (name, ty,) in self._fileSystemType.items():
             if name == 'ext2':
                 result = _ped.file_system_probe_specific(type, self._geometry)
 
@@ -282,7 +282,7 @@ class FileSystemProbeSpecificTestCase(RequiresFileSystem):
                 self.assertLessEqual(result.length, self._geometry.length)
                 self.assertEqual(result.dev, self._device)
             else:
-                result = _ped.file_system_probe_specific(type, self._geometry)
+                result = _ped.file_system_probe_specific(ty, self._geometry)
                 self.assertEqual(result, None)
 
 class FileSystemTypeGetTestCase(unittest.TestCase):

--- a/tests/test_parted_alignment.py
+++ b/tests/test_parted_alignment.py
@@ -23,7 +23,7 @@
 import _ped
 import parted
 import unittest
-from tests.baseclass import *
+from tests.baseclass import RequiresDevice
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require

--- a/tests/test_parted_alignment.py
+++ b/tests/test_parted_alignment.py
@@ -143,7 +143,7 @@ class AlignmentStrTestCase(unittest.TestCase):
         self.fail("Unimplemented test case.")
 
 # And then a suite to hold all the test cases for this module.
-def suite():
+def makeSuite():
     suite = unittest.TestSuite()
     suite.addTest(AlignmentNewTestCase())
     suite.addTest(AlignmentGetSetTestCase())
@@ -156,6 +156,6 @@ def suite():
     suite.addTest(AlignmentStrTestCase())
     return suite
 
-s = suite()
+s = makeSuite()
 if __name__ == "__main__":
     unittest.main(defaultTest='s', verbosity=2)

--- a/tests/test_parted_constraint.py
+++ b/tests/test_parted_constraint.py
@@ -23,7 +23,7 @@
 import _ped
 import parted
 import unittest
-from tests.baseclass import *
+from tests.baseclass import RequiresDevice
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require

--- a/tests/test_parted_constraint.py
+++ b/tests/test_parted_constraint.py
@@ -157,7 +157,7 @@ class ConstraintStrTestCase(unittest.TestCase):
         self.fail("Unimplemented test case.")
 
 # And then a suite to hold all the test cases for this module.
-def suite():
+def makeSuite():
     suite = unittest.TestSuite()
     suite.addTest(ConstraintNewTestCase())
     suite.addTest(ConstraintGetSetTestCase())
@@ -169,6 +169,6 @@ def suite():
     suite.addTest(ConstraintStrTestCase())
     return suite
 
-s = suite()
+s = makeSuite()
 if __name__ == "__main__":
     unittest.main(defaultTest='s', verbosity=2)

--- a/tests/test_parted_device.py
+++ b/tests/test_parted_device.py
@@ -157,7 +157,7 @@ class DeviceStrTestCase(unittest.TestCase):
         self.fail("Unimplemented test case.")
 
 # And then a suite to hold all the test cases for this module.
-def suite():
+def makeSuite():
     suite = unittest.TestSuite()
     suite.addTest(DeviceNewTestCase())
     suite.addTest(DeviceGetSetTestCase())
@@ -183,6 +183,6 @@ def suite():
     suite.addTest(DeviceStrTestCase())
     return suite
 
-s = suite()
+s = makeSuite()
 if __name__ == "__main__":
     unittest.main(defaultTest='s', verbosity=2)

--- a/tests/test_parted_device.py
+++ b/tests/test_parted_device.py
@@ -20,10 +20,8 @@
 # Red Hat Author(s): David Cantrell <dcantrell@redhat.com>
 #
 
-import _ped
-import parted
 import unittest
-from tests.baseclass import *
+from tests.baseclass import RequiresDevice
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require

--- a/tests/test_parted_disk.py
+++ b/tests/test_parted_disk.py
@@ -23,7 +23,7 @@
 import parted
 import unittest
 
-from tests.baseclass import *
+from tests.baseclass import RequiresDisk
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require

--- a/tests/test_parted_disk.py
+++ b/tests/test_parted_disk.py
@@ -256,7 +256,7 @@ class DiskStrTestCase(unittest.TestCase):
         self.fail("Unimplemented test case.")
 
 # And then a suite to hold all the test cases for this module.
-def suite():
+def makeSuite():
     suite = unittest.TestSuite()
     suite.addTest(DiskNewTestCase())
     suite.addTest(DiskGetSetTestCase())
@@ -298,6 +298,6 @@ def suite():
     suite.addTest(DiskStrTestCase())
     return suite
 
-s = suite()
+s = makeSuite()
 if __name__ == "__main__":
     unittest.main(defaultTest='s', verbosity=2)

--- a/tests/test_parted_filesystem.py
+++ b/tests/test_parted_filesystem.py
@@ -50,7 +50,7 @@ class FileSystemStrTestCase(unittest.TestCase):
         self.fail("Unimplemented test case.")
 
 # And then a suite to hold all the test cases for this module.
-def suite():
+def makeSuite():
     suite = unittest.TestSuite()
     suite.addTest(FileSystemNewTestCase())
     suite.addTest(FileSystemGetSetTestCase())
@@ -58,6 +58,6 @@ def suite():
     suite.addTest(FileSystemStrTestCase())
     return suite
 
-s = suite()
+s = makeSuite()
 if __name__ == "__main__":
     unittest.main(defaultTest='s', verbosity=2)

--- a/tests/test_parted_filesystem.py
+++ b/tests/test_parted_filesystem.py
@@ -20,7 +20,6 @@
 # Red Hat Author(s): David Cantrell <dcantrell@redhat.com>
 #
 
-import parted
 import unittest
 
 # One class per method, multiple tests per class.  For these simple methods,

--- a/tests/test_parted_geometry.py
+++ b/tests/test_parted_geometry.py
@@ -23,7 +23,7 @@
 import parted
 import unittest
 
-from tests.baseclass import *
+from tests.baseclass import RequiresDevice
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require

--- a/tests/test_parted_geometry.py
+++ b/tests/test_parted_geometry.py
@@ -127,7 +127,7 @@ class GeometryStrTestCase(unittest.TestCase):
         self.fail("Unimplemented test case.")
 
 # And then a suite to hold all the test cases for this module.
-def suite():
+def makeSuite():
     suite = unittest.TestSuite()
     suite.addTest(GeometryNewTestCase())
     suite.addTest(GeometryGetSetTestCase())
@@ -147,6 +147,6 @@ def suite():
     suite.addTest(GeometryStrTestCase())
     return suite
 
-s = suite()
+s = makeSuite()
 if __name__ == "__main__":
     unittest.main(defaultTest='s', verbosity=2)

--- a/tests/test_parted_parted.py
+++ b/tests/test_parted_parted.py
@@ -142,7 +142,7 @@ class VersionTestCase(unittest.TestCase):
         self.assertEqual(ver['pyparted'], _ped.pyparted_version())
 
 # And then a suite to hold all the test cases for this module.
-def suite():
+def makeSuite():
     suite = unittest.TestSuite()
     suite.addTest(FormatBytesTestCase())
     suite.addTest(BytesToSectorsTestCase())
@@ -157,6 +157,6 @@ def suite():
     suite.addTest(VersionTestCase())
     return suite
 
-s = suite()
+s = makeSuite()
 if __name__ == "__main__":
     unittest.main(defaultTest='s', verbosity=2)

--- a/tests/test_parted_parted.py
+++ b/tests/test_parted_parted.py
@@ -25,7 +25,7 @@ from __future__ import division
 import _ped
 import parted
 import unittest
-from tests.baseclass import *
+from tests.baseclass import RequiresDevice, RequiresDeviceNode
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require

--- a/tests/test_parted_partition.py
+++ b/tests/test_parted_partition.py
@@ -126,7 +126,7 @@ class PartitionStrTestCase(unittest.TestCase):
         self.fail("Unimplemented test case.")
 
 # And then a suite to hold all the test cases for this module.
-def suite():
+def makeSuite():
     suite = unittest.TestSuite()
     suite.addTest(PartitionNewTestCase())
     suite.addTest(PartitionGetSetTestCase())
@@ -145,6 +145,6 @@ def suite():
     suite.addTest(PartitionStrTestCase())
     return suite
 
-s = suite()
+s = makeSuite()
 if __name__ == "__main__":
     unittest.main(defaultTest='s', verbosity=2)

--- a/tests/test_parted_partition.py
+++ b/tests/test_parted_partition.py
@@ -23,7 +23,7 @@
 import parted
 import unittest
 
-from tests.baseclass import *
+from tests.baseclass import RequiresDisk
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require


### PR DESCRIPTION
I have one question about this patch set, though.  pocketlint is a python3 thing, which means that I need to have pyparted built with python3 support before it can be checked.  tests/pylint is now python3-only, so the "make check" target should probably be modified to enforce that.  Is that something I should do, or is it going to be a problem that we won't be able to use pylint+the python2 version?