### PR TITLE
Beware of Python 3's version of the map() built-in function

### DIFF
--- a/tests/test_parted_parted.py
+++ b/tests/test_parted_parted.py
@@ -85,7 +85,8 @@ class GetAllDevicesTestCase(unittest.TestCase):
         self.assertEqual(type(self.devices).__name__, 'list')
 
         # And make sure each element of the list is a parted.Device
-        map(lambda s: self.assertIsInstance(s, parted.Device), self.devices)
+        for dev in self.devices:
+            self.assertIsInstance(dev, parted.Device)
 
 @unittest.skip("Unimplemented test case.")
 class ProbeForSpecificFileSystemTestCase(unittest.TestCase):


### PR DESCRIPTION
It not only returns an iterator in Python 3, it actually works in the lazy
evaluation fashion. So if its returned value is not iterated over, the passed
function is not called on the iterable's items. Let's use a for cycle in these
places to make the iteration and function calls explicit.