### PR TITLE
Add test cases for _ped.FileSystem

### DIFF
--- a/tests/test__ped_filesystem.py
+++ b/tests/test__ped_filesystem.py
@@ -18,25 +18,41 @@
 # Red Hat Author(s): Chris Lumens <clumens@redhat.com>
 #                    David Cantrell <dcantrell@redhat.com>
 #
+import _ped
 import unittest
+import baseclass
 
 # One class per method, multiple tests per class.  For these simple methods,
 # that seems like good organization.  More complicated methods may require
 # multiple classes and their own test suite.
-@unittest.skip("Unimplemented test case.")
-class FileSystemNewTestCase(unittest.TestCase):
-    # TODO
+class FileSystemNewTestCase(baseclass.RequiresFileSystem):
     def runTest(self):
-        self.fail("Unimplemented test case.")
+        fstype = _ped.file_system_type_get("ext2")
 
-@unittest.skip("Unimplemented test case.")
-class FileSystemGetSetTestCase(unittest.TestCase):
-    # TODO
-    def runTest(self):
-        self.fail("Unimplemented test case.")
+        with self.assertRaises(TypeError):
+            _ped.FileSystem(type=None, geom=None)
+            _ped.FileSystem(type=fstype, geom=None)
 
-@unittest.skip("Unimplemented test case.")
-class FileSystemStrTestCase(unittest.TestCase):
-    # TODO
+        fs = _ped.FileSystem(type=fstype, geom=self._geometry)
+        self.assertIsInstance(fs, _ped.FileSystem)
+
+class FileSystemGetSetTestCase(baseclass.RequiresFileSystem):
     def runTest(self):
-        self.fail("Unimplemented test case.")
+        fstype = _ped.file_system_type_get("ext2")
+        fs = _ped.FileSystem(type=fstype, geom=self._geometry)
+
+        self.assertIsInstance(fs, _ped.FileSystem)
+        self.assertEqual(fs.type, fstype)
+        self.assertEqual(getattr(fs, "type"), fstype)
+        # read-only attribute
+        self.assertRaises(TypeError, setattr, fs, "type", fstype)
+        self.assertRaises(AttributeError, getattr, fs, "junk")
+
+
+class FileSystemStrTestCase(baseclass.RequiresFileSystem):
+    def runTest(self):
+        fstype = _ped.file_system_type_get("ext2")
+        fs = _ped.FileSystem(type=fstype, geom=self._geometry)
+        # don't use assertEqual b/c __str__ includes memory addresses of
+        # fstype and geom objects. This is easier.
+        self.assertTrue(str(fs).startswith("_ped.FileSystem instance --"))


### PR DESCRIPTION
This is initial attempt to create missing test cases for _ped.FileSystem. 