### PR TITLE
Do not support and use hashing on pyparted's objects (#1229186)

### DIFF
--- a/src/parted/alignment.py
+++ b/src/parted/alignment.py
@@ -58,9 +58,6 @@ class Alignment(object):
         if not isinstance(self, other.__class__):
             return True
 
-        if getattr(other, "__hash__", None):
-            return hash(self) != hash(other)
-
         return self.offset != other.offset or self.grainSize != other.grainSize
 
     def __str__(self):
@@ -70,9 +67,6 @@ class Alignment(object):
              {"offset": self.offset, "grainSize": self.grainSize,
               "ped": self.__alignment})
         return s
-
-    def __hash__(self):
-        return hash(str(self))
 
     @localeC
     def intersect(self, b):

--- a/src/parted/device.py
+++ b/src/parted/device.py
@@ -66,9 +66,6 @@ class Device(object):
         if not isinstance(self, other.__class__):
             return True
 
-        if getattr(other, "__hash__", None):
-            return hash(self) != hash(other)
-
         return self.model != other.model or self.path != other.path or self.type != other.type or self.length != other.length
 
     def __getCHS(self, geometry):
@@ -185,22 +182,6 @@ class Device(object):
               "hardwareGeom": self.hardwareGeometry, "biosGeom": self.biosGeometry,
               "ped": self.__device})
         return s
-
-    @property
-    def _hashstr(self):
-        s = ("  model: %(model)s  path: %(path)s  type: %(type)s\n"
-             "  sectorSize: %(sectorSize)s  physicalSectorSize:  %(physSectorSize)s\n"
-             "  length: %(length)s\n"
-             "  hardwareGeometry: %(hardwareGeom)s  biosGeometry: %(biosGeom)s\n"
-             "  PedDevice: %(ped)r" %
-             {"model": self.model, "path": self.path, "type": self.type,
-              "sectorSize": self.sectorSize, "physSectorSize": self.physicalSectorSize,
-              "length": self.length, "hardwareGeom": self.hardwareGeometry,
-              "biosGeom": self.biosGeometry, "ped": self.__device})
-        return s
-
-    def __hash__(self):
-        return hash(self._hashstr)
 
     @localeC
     def clobber(self):

--- a/src/parted/disk.py
+++ b/src/parted/disk.py
@@ -77,9 +77,6 @@ class Disk(object):
         if not isinstance(self, other.__class__):
             return True
 
-        if getattr(other, "__hash__", None):
-            return hash(self) != hash(other)
-
         return self.device != other.device or not self._hasSameParts(other)
 
     def __str__(self):
@@ -94,17 +91,6 @@ class Disk(object):
               "partitions": self.partitions, "device": self.device,
               "ped": self.__disk})
         return s
-
-    @property
-    def _hash_str(self):
-        s = ("  type: %(type)s\n"
-             "  device: %(device)r\n"
-             "  PedDisk: %(ped)r" %
-             {"type": self.type, "device": self.device, "ped": self.__disk})
-        return s
-
-    def __hash__(self):
-        return hash(self._hash_str)
 
     def __getPartitions(self):
         """Construct a list of partitions on the disk.  This is called only as

--- a/src/parted/filesystem.py
+++ b/src/parted/filesystem.py
@@ -65,9 +65,6 @@ class FileSystem(object):
         if not isinstance(self, other.__class__):
             return True
 
-        if getattr(other, "__hash__", None):
-            return hash(self) != hash(other)
-
         return self.type != other.type or self.geometry != other.geometry
 
     def __str__(self):
@@ -77,17 +74,6 @@ class FileSystem(object):
              {"type": self.type, "geometry": self.geometry,
               "checked": self.checked, "ped": self.__fileSystem})
         return s
-
-    @property
-    def _hash_str(self):
-        s = ("  type: %(type)s  geometry: %(geometry)r\n"
-             "  PedFileSystem: %(ped)r" %
-             {"type": self.type, "geometry": self.geometry,
-              "ped": self.__fileSystem})
-        return s
-
-    def __hash__(self):
-        return hash(self._hash_str)
 
     @property
     def type(self):

--- a/src/parted/geometry.py
+++ b/src/parted/geometry.py
@@ -70,9 +70,6 @@ class Geometry(object):
         if not isinstance(self, other.__class__):
             return True
 
-        if getattr(other, "__hash__", None):
-            return hash(self) != hash(other)
-
         return self.device != other.device or self.start != other.start or self.length != other.length
 
     def __str__(self):
@@ -82,17 +79,6 @@ class Geometry(object):
              {"start": self.start, "end": self.end, "length": self.length,
               "device": self.device, "ped": self.__geometry})
         return s
-
-    @property
-    def _hash_str(self):
-        s = ("  start: %(start)s  end: %(end)s  length: %(length)s\n"
-             "  device: %(device)r  PedGeometry: %(ped)r" %
-             {"start": self.start, "end": self.end, "length": self.length,
-              "device": self.device, "ped": self.__geometry})
-        return s
-
-    def __hash__(self):
-        return hash(self._hash_str)
 
     @property
     def device(self):

--- a/src/parted/partition.py
+++ b/src/parted/partition.py
@@ -75,9 +75,6 @@ class Partition(object):
         if not isinstance(self, other.__class__):
             return True
 
-        if getattr(other, "__hash__", None):
-            return hash(self) != hash(other)
-
         return self.path != other.path or self.type != other.type or self.geometry != other.geometry or self.fileSystem != other.fileSystem
 
     def __str__(self):
@@ -96,25 +93,6 @@ class Partition(object):
               "type": self.type, "name": name, "active": self.active,
               "busy": self.busy, "ped": self.__partition})
         return s
-
-    @property
-    def _hash_str(self):
-        try:
-            name = self.name
-        except parted.PartitionException:
-            name = None
-
-        s = ("  disk: %(disk)r\n"
-             "  number: %(number)s  path: %(path)s  type: %(type)s\n"
-             "  name: %(name)s\n"
-             "  geometry: %(geometry)r  PedPartition: %(ped)r" %
-             {"disk": self.disk, "number": self.number, "path": self.path,
-              "type": self.type, "name": name, "geometry": self.geometry,
-              "ped": self.__partition})
-        return s
-
-    def __hash__(self):
-        return hash(self._hash_str)
 
     def __writeOnly(self, prop):
         raise parted.WriteOnlyProperty(prop)


### PR DESCRIPTION
The current implementations of __hash__ methods are not much useful because the
hash is calculated from things like object addresses, which makes it unusable
for comparing two (deep) copies of the same object which is what's usually done.