### PR TITLE
Added 3 new unittests to test_parted_disk.py

### DIFF
--- a/tests/test_parted_disk.py
+++ b/tests/test_parted_disk.py
@@ -88,11 +88,19 @@ class DiskSupportsFeatureTestCase(unittest.TestCase):
         # TODO
         self.fail("Unimplemented test case.")
 
-@unittest.skip("Unimplemented test case.")
-class DiskAddPartitionTestCase(unittest.TestCase):
+class DiskAddPartitionTestCase(RequiresDisk):
+    """
+        addPartition should return True if partition is added successfully(even
+        without committing)
+    """
     def runTest(self):
-        # TODO
-        self.fail("Unimplemented test case.")
+        self.disk.setFlag(parted.DISK_CYLINDER_ALIGNMENT)
+
+        length = 100
+        geom = parted.Geometry(self.device, start=100, length=length)
+        part = parted.Partition(self.disk, parted.PARTITION_NORMAL, geometry=geom)
+        constraint = parted.Constraint(exactGeom=geom)
+        self.assertTrue(self.disk.addPartition(part, constraint))
 
 @unittest.skip("Unimplemented test case.")
 class DiskRemovePartitionTestCase(unittest.TestCase):
@@ -142,17 +150,28 @@ class DiskGetPartitionBySectorTestCase(unittest.TestCase):
         # TODO
         self.fail("Unimplemented test case.")
 
-@unittest.skip("Unimplemented test case.")
-class DiskGetMaxLogicalPartitionsTestCase(unittest.TestCase):
+class DiskGetMaxLogicalPartitionsTestCase(RequiresDisk):
+    """
+        getMaxLogicalPartitions return int values based on which type of disk
+        is used. It search for occurrence of keys in device path(e.g. /dev/sda)
+        and compare it with predefined values("sd": 11). As unittest
+        environment is using file with generic name(e.g.
+        /tmp/temp-device-C64w78), test focus only on type of returned value
+    """
     def runTest(self):
-        # TODO
-        self.fail("Unimplemented test case.")
+        self.assertIsInstance(self.disk.getMaxLogicalPartitions(), int)
 
-@unittest.skip("Unimplemented test case.")
-class DiskGetMaxSupportedPartitionCountTestCase(unittest.TestCase):
+class DiskGetMaxSupportedPartitionCountTestCase(RequiresDisk):
+    """
+        maxSupportedPartitionCount should return value 64, based on default
+        value MAX_NUM_PARTS(parted/libparted/arch/linux.c) applied if it cannot
+        find value in /sys/block/DEV/ext_range (RequiresDisk implies there is
+        no ext_range value). Also see testcase
+        DiskGetMaxSupportedPartitionCountTestCase in tests/test__ped_disk ,
+        which tests value returned by source C function defined in module _ped
+    """
     def runTest(self):
-        # TODO
-        self.fail("Unimplemented test case.")
+        self.assertEqual(self.disk.maxSupportedPartitionCount, 64)
 
 class DiskMaxPartitionLengthTestCase(RequiresDisk):
     def runTest(self):


### PR DESCRIPTION
Adding first 3 new unittests.
1) DiskAddPartitionTestCase: in comment
2) DiskGetMaxSupportedPartitionCountTestCase: in comment
3) DiskGetMaxLogicalPartitionsTestCase: it is temporary solution, which tests only type of returned value. Actually working on solution, which will tests all defined values one by one.
Considering 2 options: a)create new class FakeDevice(cloned from Device, inherits from Device), but all returned values are hardcoded except attribute path, which will be changed
b)create directly unittest class, which will inherit from unittest.TestCase and contains all needed attributes, conditions(included in baseclass.py) to make available to change default path of temporary file(/tmp/temp-device-) to one simulating block device based on path(/dev/hd-temp-device, or /tmp/<type>-temp-device)
Actually selected b) solution.
Please, write some comments in return if possible. Some guide will be helpful.