### PR TITLE
Return to using PyLong_*LongLong functions for PedSector values (#1300073)

### DIFF
--- a/src/pyconstraint.c
+++ b/src/pyconstraint.c
@@ -264,9 +264,9 @@ PyObject *_ped_Constraint_get(_ped_Constraint *self, void *closure) {
     }
 
     if (!strcmp(member, "min_size")) {
-        return PyLong_FromLong(self->min_size);
+        return PyLong_FromLongLong(self->min_size);
     } else if (!strcmp(member, "max_size")) {
-        return PyLong_FromLong(self->max_size);
+        return PyLong_FromLongLong(self->max_size);
     } else {
         PyErr_Format(PyExc_AttributeError, "_ped.Constraint object has no attribute %s", member);
         return NULL;
@@ -282,12 +282,12 @@ int _ped_Constraint_set(_ped_Constraint *self, PyObject *value, void *closure) {
     }
 
     if (!strcmp(member, "min_size")) {
-        self->min_size = PyLong_AsLong(value);
+        self->min_size = PyLong_AsLongLong(value);
         if (PyErr_Occurred()) {
             return -1;
         }
     } else if (!strcmp(member, "max_size")) {
-        self->max_size = PyLong_AsLong(value);
+        self->max_size = PyLong_AsLongLong(value);
         if (PyErr_Occurred()) {
             return -1;
         }

--- a/src/pydevice.c
+++ b/src/pydevice.c
@@ -266,11 +266,11 @@ PyObject *_ped_Device_get(_ped_Device *self, void *closure) {
     } else if (!strcmp(member, "type")) {
         return PyLong_FromLong(self->type);
     } else if (!strcmp(member, "sector_size")) {
-        return PyLong_FromLong(self->sector_size);
+        return PyLong_FromLongLong(self->sector_size);
     } else if (!strcmp(member, "phys_sector_size")) {
-        return PyLong_FromLong(self->phys_sector_size);
+        return PyLong_FromLongLong(self->phys_sector_size);
     } else if (!strcmp(member, "length")) {
-        return PyLong_FromLong(self->length);
+        return PyLong_FromLongLong(self->length);
     } else if (!strcmp(member, "open_count")) {
         return Py_BuildValue("i", self->open_count);
     } else if (!strcmp(member, "read_only")) {
@@ -819,7 +819,7 @@ PyObject *py_ped_device_check(PyObject *s, PyObject *args) {
     ret = ped_device_check(device, out_buf, start, count);
     free(out_buf);
 
-    return PyLong_FromLong(ret);
+    return PyLong_FromLongLong(ret);
 }
 
 PyObject *py_ped_device_get_constraint(PyObject *s, PyObject *args) {

--- a/src/pydisk.c
+++ b/src/pydisk.c
@@ -928,7 +928,7 @@ PyObject *py_ped_disk_max_partition_length(PyObject *s, PyObject *args) {
     if (!disk)
         return NULL;
 
-    return PyLong_FromUnsignedLong(ped_disk_max_partition_length(disk));
+    return PyLong_FromUnsignedLongLong(ped_disk_max_partition_length(disk));
 }
 
 PyObject *py_ped_disk_max_partition_start_sector(PyObject *s, PyObject *args) {
@@ -938,7 +938,7 @@ PyObject *py_ped_disk_max_partition_start_sector(PyObject *s, PyObject *args) {
     if (!disk)
         return NULL;
 
-    return PyLong_FromUnsignedLong(ped_disk_max_partition_start_sector(disk));
+    return PyLong_FromUnsignedLongLong(ped_disk_max_partition_start_sector(disk));
 }
 
 PyObject *py_ped_disk_set_flag(PyObject *s, PyObject *args) {

--- a/src/pygeom.c
+++ b/src/pygeom.c
@@ -183,11 +183,11 @@ PyObject *_ped_Geometry_get(_ped_Geometry *self, void *closure) {
     }
 
     if (!strcmp(member, "start")) {
-        return PyLong_FromLong(self->ped_geometry->start);
+        return PyLong_FromLongLong(self->ped_geometry->start);
     } else if (!strcmp(member, "length")) {
-        return PyLong_FromLong(self->ped_geometry->length);
+        return PyLong_FromLongLong(self->ped_geometry->length);
     } else if (!strcmp(member, "end")) {
-        return PyLong_FromLong(self->ped_geometry->end);
+        return PyLong_FromLongLong(self->ped_geometry->end);
     } else {
         PyErr_Format(PyExc_AttributeError, "_ped.Geometry object has no attribute %s", member);
         return NULL;
@@ -205,20 +205,20 @@ int _ped_Geometry_set(_ped_Geometry *self, PyObject *value, void *closure) {
     }
 
     if (!strcmp(member, "start")) {
-        val = PyLong_AsLong(value);
+        val = PyLong_AsLongLong(value);
         if (PyErr_Occurred()) {
             return -1;
         }
         ret = ped_geometry_set_start(self->ped_geometry, val);
     } else if (!strcmp(member, "length")) {
-        val = PyLong_AsLong(value);
+        val = PyLong_AsLongLong(value);
         if (PyErr_Occurred()) {
             return -1;
         }
         ret = ped_geometry_set(self->ped_geometry, self->ped_geometry->start,
                                val);
     } else if (!strcmp(member, "end")) {
-        val = PyLong_AsLong(value);
+        val = PyLong_AsLongLong(value);
         if (PyErr_Occurred()) {
             return -1;
         }
@@ -717,7 +717,7 @@ PyObject *py_ped_geometry_check(PyObject *s, PyObject *args) {
     ped_timer_destroy(out_timer);
     free(out_buf);
 
-    return PyLong_FromLong(ret);
+    return PyLong_FromLongLong(ret);
 }
 
 PyObject *py_ped_geometry_map(PyObject *s, PyObject *args) {

--- a/src/pynatmath.c
+++ b/src/pynatmath.c
@@ -126,9 +126,9 @@ PyObject *_ped_Alignment_get(_ped_Alignment *self, void *closure) {
     }
 
     if (!strcmp(member, "offset")) {
-        return PyLong_FromLong(self->offset);
+        return PyLong_FromLongLong(self->offset);
     } else if (!strcmp(member, "grain_size")) {
-        return PyLong_FromLong(self->grain_size);
+        return PyLong_FromLongLong(self->grain_size);
     } else {
         PyErr_Format(PyExc_AttributeError, "_ped.Alignment object has no attribute %s", member);
         return NULL;
@@ -143,12 +143,12 @@ int _ped_Alignment_set(_ped_Alignment *self, PyObject *value, void *closure) {
     }
 
     if (!strcmp(member, "offset")) {
-        self->offset = PyLong_AsLong(value);
+        self->offset = PyLong_AsLongLong(value);
         if (PyErr_Occurred()) {
             return -1;
         }
     } else if (!strcmp(member, "grain_size")) {
-        self->grain_size = PyLong_AsLong(value);
+        self->grain_size = PyLong_AsLongLong(value);
         if (PyErr_Occurred()) {
             return -1;
         }
@@ -252,7 +252,7 @@ PyObject *py_ped_alignment_align_up(PyObject *s, PyObject *args) {
         return NULL;
     }
 
-    return PyLong_FromLong(ret);
+    return PyLong_FromLongLong(ret);
 }
 
 PyObject *py_ped_alignment_align_down(PyObject *s, PyObject *args) {
@@ -284,7 +284,7 @@ PyObject *py_ped_alignment_align_down(PyObject *s, PyObject *args) {
         return NULL;
     }
 
-    return PyLong_FromLong(ret);
+    return PyLong_FromLongLong(ret);
 }
 
 PyObject *py_ped_alignment_align_nearest(PyObject *s, PyObject *args) {
@@ -316,7 +316,7 @@ PyObject *py_ped_alignment_align_nearest(PyObject *s, PyObject *args) {
         return NULL;
     }
 
-    return PyLong_FromLong(ret);
+    return PyLong_FromLongLong(ret);
 }
 
 PyObject *py_ped_alignment_is_aligned(PyObject *s, PyObject *args) {


### PR DESCRIPTION


Commit 6e62a95b5878be04 changed a number of conversions from LongLong to
Long. This works fine on 64bit architectures, but on 32bit it results in
an overflow on devices greater than 2TiB.