### PR TITLE
Fix two problems found from running "make ci".

### DIFF
--- a/src/parted/cachedlist.py
+++ b/src/parted/cachedlist.py
@@ -82,9 +82,9 @@ class CachedList(Sequence):
         self.__rebuildList()
         return self._lst.count(value)
 
-    def index(self, value):
+    def index(self, value, *args, **kwargs):
         self.__rebuildList()
-        return self._lst.index(value)
+        return self._lst.index(value, *args, **kwargs)
 
     def invalidate(self):
         """Indicate that the list is no longer valid, due to some external

--- a/tests/test__ped_geometry.py
+++ b/tests/test__ped_geometry.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2008-2011  Red Hat, Inc.
+# Copyright (C) 2008-2016  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -19,6 +19,7 @@
 #
 
 import _ped
+import six
 from tests.baseclass import RequiresDevice
 
 # One class per method, multiple tests per class.  For these simple methods,
@@ -374,4 +375,9 @@ class GeometryStrTestCase(RequiresDevice):
         lines = str(self.g).split('\n')
         self.assertEqual(lines[0], '_ped.Geometry instance --')
         self.assertEqual(lines[1], '  start: 10  end: 109  length: 100')
-        self.assertRegexpMatches(lines[2], '^  device: <_ped.Device object at .*')
+
+        if six.PY2:
+            # pylint: disable=deprecated-method
+            self.assertRegexpMatches(lines[2], '^  device: <_ped.Device object at .*')
+        else:
+            self.assertRegex(lines[2], '^  device: <_ped.Device object at .*')


### PR DESCRIPTION
These are:

************* Module tests.test__ped_geometry
W1505(deprecated-method):377,8: GeometryStrTestCase.runTest: Using deprecated method assertRegexpMatches()
************* Module parted.cachedlist
W0221(arguments-differ): 85,4: CachedList.index: Arguments number differs from overridden 'index' method

The first is a python3 vs. python2 thing, so protect that with a check
for the version and tell pylint to ignore it when not appropriate.  The
second is because Sequence.index now takes extra arguments.  Accept
those in a way that shouldn't break on older versions.