### PR TITLE
Added testcases to check flag operations.

### DIFF
--- a/tests/test_parted_partition.py
+++ b/tests/test_parted_partition.py
@@ -93,32 +93,100 @@ class PartitionGetSetTestCase(PartitionNewTestCase):
         with self.assertRaises((AttributeError)):
             self.part.blah
 
-@unittest.skip("Unimplemented test case.")
-class PartitionGetFlagTestCase(unittest.TestCase):
-    def runTest(self):
-        # TODO
-        self.fail("Unimplemented test case.")
+class PartitionSetFlagTestCase(PartitionNewTestCase):
+    """
+        Method setFlag should return True, if flag was set to "on" state.
+        Next few flag testcases will inherit from setUp.
+        This testcase checks if method setFlag returns:
+        1)correct bool when state of BOOT and RAID flags is set to "on"
+        on partition.
+        2)raises user defined exception on unavailable flag
+        See parted/include/parted/disk.in.h for flag numbers.
+        Partition flags are dependent on disklabel. In this case msdos label is
+        used, see parted library libparted/labels/dos.c for flags availability.
+    """
+    def setUp(self):
+        super(PartitionSetFlagTestCase, self).setUp()
+        self.neg_msg = "Method returns unexpected bool value"
+        self.flag_set = self.part.setFlag(1)
+        self.flag_set1 = self.part.setFlag(5)
 
-@unittest.skip("Unimplemented test case.")
-class PartitionSetFlagTestCase(unittest.TestCase):
     def runTest(self):
-        # TODO
-        self.fail("Unimplemented test case.")
+        self.assertTrue(self.flag_set, self.neg_msg)
+        self.assertTrue(self.flag_set1, self.neg_msg)
+        with self.assertRaises((parted.PartitionException,)):
+            self.part.setFlag(2)
 
-@unittest.skip("Unimplemented test case.")
-class PartitionUnsetFlagTestCase(unittest.TestCase):
+class PartitionGetFlagTestCase(PartitionSetFlagTestCase):
+    """
+        Method getFlag should return correct bool value depending on flag
+        setting(flag is off=>False; on=>True).
+        This testcase checks if method getFlag returns:
+        1)correct bools when checks state of BOOT(on), RAID(on) and LVM(off)
+        flags.
+    """
     def runTest(self):
-        # TODO
-        self.fail("Unimplemented test case.")
+        self.assertTrue(self.part.getFlag(1), self.neg_msg)
+        self.assertTrue(self.part.getFlag(5), self.neg_msg)
+        self.assertFalse(self.part.getFlag(6), self.neg_msg)
+
+class PartitionUnsetFlagTestCase(PartitionSetFlagTestCase):
+    """
+        Method unsetFlag should set flag to "off" state and return True on
+        success. PartitionException should be raised on error.
+        This testcase checks if method unsetFlag returns:
+        1)correct bool value when flag is unset and if flag is in state 'off'
+        2)raises user defined exception on unavailable flag
+    """
+    def runTest(self):
+        self.assertTrue(self.part.unsetFlag(1), self.neg_msg)
+        self.assertFalse(self.part.getFlag(1), self.neg_msg)
+
+        with self.assertRaises((parted.PartitionException,)):
+            self.part.unsetFlag(2)
+
+class PartitionIsFlagAvailableTestCase(PartitionNewTestCase):
+    '''
+        Method isFlagAvailable should return bool value whenever flag is
+        available according to chosen disk label setting and disk proportions
+        itself.
+        This testcase checks if method isFlagAvailable returns:
+        1)bool value without traceback
+        2)false on nonexistent flag
+        3)raises user defined exception when called on inactive partition
+    '''
+    def runTest(self):
+        for f in ['PARTITION_BOOT', 'PARTITION_ROOT', 'PARTITION_SWAP',
+                  'PARTITION_HIDDEN', 'PARTITION_RAID', 'PARTITION_LVM',
+                  'PARTITION_LBA', 'PARTITION_HPSERVICE',
+                  'PARTITION_PALO', 'PARTITION_PREP',
+                  'PARTITION_MSFT_RESERVED',
+                  'PARTITION_APPLE_TV_RECOVERY',
+                  'PARTITION_BIOS_GRUB', 'PARTITION_DIAG',
+                  'PARTITION_MSFT_DATA', 'PARTITION_IRST',
+                  'PARTITION_ESP', 'PARTITION_NONFS']:
+            if not hasattr(parted, f):
+                continue
+            attr = getattr(parted, f)
+            self.assertIsInstance(self.part.isFlagAvailable(attr), bool)
+
+        self.assertFalse(self.part.isFlagAvailable(1000))
+
+        with self.assertRaises((parted.PartitionException,)):
+            self.part = parted.Partition(self.disk, parted.PARTITION_FREESPACE,
+            geometry=self.geom)
+            self.part.isFlagAvailable(parted.PARTITION_BOOT)
+
+class PartitionGetFlagsAsStringTestCase(PartitionSetFlagTestCase):
+    '''
+        Method getFlagsAsString should return all flags which are in state "on"
+        as comma separated list.
+    '''
+    def runTest(self):
+        self.assertEqual(self.part.getFlagsAsString(), 'boot, raid')
 
 @unittest.skip("Unimplemented test case.")
 class PartitionGetMaxGeometryTestCase(unittest.TestCase):
-    def runTest(self):
-        # TODO
-        self.fail("Unimplemented test case.")
-
-@unittest.skip("Unimplemented test case.")
-class PartitionIsFlagAvailableTestCase(unittest.TestCase):
     def runTest(self):
         # TODO
         self.fail("Unimplemented test case.")
@@ -147,12 +215,6 @@ class PartitionGetLengthTestCase(RequiresDisk):
 
         self.assertEqual(part.getLength(), part.geometry.length)
         self.assertEqual(part.getLength(), length)
-
-@unittest.skip("Unimplemented test case.")
-class PartitionGetFlagsAsStringTestCase(unittest.TestCase):
-    def runTest(self):
-        # TODO
-        self.fail("Unimplemented test case.")
 
 @unittest.skip("Unimplemented test case.")
 class PartitionGetMaxAvailableSizeTestCase(unittest.TestCase):


### PR DESCRIPTION
Tested methods are: getFlag, setFlag, unsetFLag, isFlagAvailable and getFlagsAsString
Reordered classes: PartitionGetFlagsAsStringTestCase, PartitionGetMaxGeometryTestCase and PartitionGetFlagsAsStringTestCase.