### PR TITLE
Fixing 2.7->3.5 compatibility issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def pkgconfig(*packages, **kwargs):
     return kwargs
 
 def check_mod_version(module, version):
-    modversion = subprocess.check_output(["pkg-config", "--modversion", module])
+    modversion = subprocess.check_output(["pkg-config", "--modversion", module]).decode('utf-8').split()[0]
     if not LooseVersion(modversion) >= LooseVersion(version):
         sys.stderr.write("*** Minimum required %s version: %s, found: %s\n" % (module, version, modversion,))
         sys.exit(1)

--- a/src/parted/disk.py
+++ b/src/parted/disk.py
@@ -56,15 +56,15 @@ class Disk(object):
         self._partitions = CachedList(lambda : self.__getPartitions())
 
     def _hasSameParts(self, other):
-        import itertools
+        import six
 
         if len(self.partitions) != len(other.partitions):
             return False
 
-        partIter = itertools.izip(self.partitions, other.partitions)
+        partIter = six.moves.zip(self.partitions, other.partitions)
         while True:
             try:
-                (left, right) = partIter.next()
+                (left, right) = next(partIter)
                 if left != right:
                     return False
             except StopIteration:

--- a/tests/test_parted_partition.py
+++ b/tests/test_parted_partition.py
@@ -91,7 +91,7 @@ class PartitionGetSetTestCase(PartitionNewTestCase):
 
         # Check that looking for invalid attributes fails properly.
         with self.assertRaises((AttributeError)):
-            self.part.blah
+            print(self.part.blah)
 
 class PartitionSetFlagTestCase(PartitionNewTestCase):
     """


### PR DESCRIPTION
1. modversion returned extra chars, which this fix removes
2. in PartitionGetSetTestCase assertion `self.assertEqual(self.part.disk, self.disk)` shows error in 3.5, because `itertools.izip` is in 3.5 made as builtin - `zip`.
2.1 also iteration in 2.7 used by using method partiter.next() is in 3.5 used as `partiter.__next__()`, with six it can be used as `next(partIter)`(see module six.py lines 520-525)

It fixes issue #30  