### PR TITLE
Make sure sizeToSectors() rounds the size up.

### DIFF
--- a/src/parted/__init__.py
+++ b/src/parted/__init__.py
@@ -25,6 +25,7 @@
 
 from __future__ import division
 
+import math
 import platform
 import re
 import sys
@@ -310,7 +311,7 @@ def sizeToSectors(bytes_, unit, sector_size):
     if unit not in __exponents.keys():
         raise SyntaxError("{:} is not a valid SI or IEC byte unit".format(unit))
     else:
-        return bytes_ * __exponents[unit] // sector_size
+        return math.ceil(bytes_ * __exponents[unit] / sector_size)
 
 # Valid disk labels per architecture type.  The list of label
 # names map to keys in the parted.diskType hash table.

--- a/tests/test_parted_parted.py
+++ b/tests/test_parted_parted.py
@@ -44,6 +44,7 @@ class BytesToSectorsTestCase(unittest.TestCase):
         self.assertRaises(SyntaxError, parted.sizeToSectors, 9, "yb", 1)
         self.assertEqual(int(parted.sizeToSectors(7777.0, "B", 512)),
                              parted.sizeToSectors(7777.0, "B", 512))
+        self.assertEqual(parted.sizeToSectors(1000, "B", 512), 2)
 
 class GetLabelsTestCase(unittest.TestCase):
     def runTest(self):


### PR DESCRIPTION
Otherwise someone using sizeToSectors() could get a partition size too small to fit in all the data. Issue: #35 .