### PR TITLE
sort input files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(name='pyparted',
       packages=['parted'],
       package_dir={'parted': 'src/parted'},
       ext_modules=[Extension('_ped',
-                             glob.glob(os.path.join('src', '*.c')),
+                             sorted(glob.glob(os.path.join('src', '*.c'))),
                              define_macros=features,
                              **pkgconfig('libparted',
                                          include_dirs=['include']))


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would usually differ.

See https://reproducible-builds.org/ for why this matters.